### PR TITLE
initial 1.2.0 ver

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
- channels:
-  - https://staging.continuum.io/prefect/fs/ansicon-feedstock/pr1/4c032d3

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+ channels:
+  - https://staging.continuum.io/prefect/fs/ansicon-feedstock/pr1/4c032d3

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,3 +1,0 @@
-target_os:
-  - unix  # [unix]
-  - win   # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,34 +12,47 @@ source:
 
 build:
   number: 0
-  script: {{ PYTHON }} -m pip install . -vv
-  noarch: python
+  Skip: True  # [py<38]
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
 
 requirements:
   host:
     - pip
-    - python >=3.8
+    - python
+    - wheel
   run:
-    - __{{ target_os }}
-    {% if target_os == 'win' %}
-    - ansicon
-    {% endif %}
-    - python >=3.8
+    - ansicon  # [win]
+    - python
 
 test:
+  source_files:
+    - tests
   imports:
     - jinxed
     - jinxed.terminfo
   commands:
     - pip check
+    - pytest -vv tests  # [py<311]
+    # seems from the tests that jinxed 1.2.0 does not support well compability tests 
+    # with ncurses >= 6.3, ncurses < 6.3 is not available for py>=311
+    - pytest -k "not test_tparm.py" -vv  # [py>=311]
   requires:
     - pip
+    - pytest
+    - ncurses <6.3 # [py<311]
+
 
 about:
   home: https://pypi.org/project/jinxed/
   summary: Jinxed Terminal Library
+  description: | 
+    Jinxed is an implementation of a subset of the Python curses library. It provides pure Python implementations of 
+    terminfo functions such as tigetstr() and tparm() as well as convenience methods for working with Windows terminals.
+  license_family: OTHER
   license: MPL-2.0
   license_file: LICENSE
+  doc_url: https://jinxed.readthedocs.io/en/stable/
+  dev_url: https://github.com/Rockhopper-Technologies/jinxed/
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,11 +35,11 @@ test:
     - pytest -vv tests  # [py<311]
     # seems from the tests that jinxed 1.2.0 does not support well compability tests 
     # with ncurses >= 6.3, ncurses < 6.3 is not available for py>=311
-    - pytest -k "not test_tparm.py" -vv  # [py>=311]
+    - pytest -k "not test_tparm.py" -vv  # [py>=311 or not win]
   requires:
     - pip
     - pytest
-    - ncurses <6.3 # [py<311]
+    - ncurses <6.3 # [py<311 or not win]
 
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 
 build:
   number: 0
-  Skip: True  # [py<38]
+  Skip: True  # [py<35]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
 
 requirements:
@@ -20,6 +20,7 @@ requirements:
     - pip
     - python
     - wheel
+    - setuptools
   run:
     - ansicon  # [win]
     - python
@@ -32,14 +33,12 @@ test:
     - jinxed.terminfo
   commands:
     - pip check
-    - pytest -vv tests  # [py<311]
-    # seems from the tests that jinxed 1.2.0 does not support well compability tests 
-    # with ncurses >= 6.3, ncurses < 6.3 is not available for py>=311
-    - pytest -k "not test_tparm.py" -vv  # [py>=311 or not win]
+    # skipping test_tparm.py as not comatible with  ncurses >= 6.4
+    - pytest -k "not test_tparm.py" -vv
   requires:
     - pip
     - pytest
-    - ncurses <6.3 # [py<311 or not win]
+    - ncurses # [not win]
 
 
 about:
@@ -51,7 +50,7 @@ about:
   license_family: OTHER
   license: MPL-2.0
   license_file: LICENSE
-  doc_url: https://jinxed.readthedocs.io/en/stable/
+  doc_url: https://jinxed.readthedocs.io/
   dev_url: https://github.com/Rockhopper-Technologies/jinxed/
 
 extra:


### PR DESCRIPTION

jinxed 1.2.0, dependency for blessed >=1.19.0
- [upstream](https://github.com/Rockhopper-Technologies/jinxed/tree/1.2.0)
- [pypi](https://pypi.org/project/jinxed/)
- [CF](https://github.com/conda-forge/jinxed-feedstock)
- updated recipe to satisfy linter
- added tests
- not fully on par with ncurses >= 6.3, therefore some tests skipped
