### PR TITLE
jinxed 2.1.0 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,18 +1,19 @@
 {% set name = "jinxed" %}
-{% set version = "1.3.0" %}
+{% set version = "2.1.0" %}
 
 package:
-  name: {{ name|lower }}
+  name: {{ name }}
   version: {{ version }}
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 1593124b18a41b7a3da3b078471442e51dbad3d77b4d4f2b0c26ab6f7d660dbf
+  sha256: 7e755b831faa2443d44fb4ce7c0202eb9c3ed39bd5bf1193365888f4f6092b54
 
 build:
   number: 0
-  Skip: true  # [py<35]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
+  # based on conda-forge - https://github.com/conda-forge/jinxed-feedstock/blob/main/recipe/meta.yaml
+  skip: true  # [py<38]
 
 requirements:
   host:
@@ -27,12 +28,13 @@ requirements:
 test:
   source_files:
     - tests
+    - terminals.toml
   imports:
     - jinxed
     - jinxed.terminfo
   commands:
     - pip check
-    - pytest -vv
+    - python -m pytest -vv tests
   requires:
     - pip
     - pytest

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,8 +12,6 @@ source:
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
-  # based on conda-forge - https://github.com/conda-forge/jinxed-feedstock/blob/main/recipe/meta.yaml
-  skip: true  # [py<38]
 
 requirements:
   host:


### PR DESCRIPTION
jinxed 2.1.0 

**Destination channel:** Defaults

### Links

- [PKG-16695]
- dev_url:        https://github.com/Rockhopper-Technologies/jinxed/tree/2.1.0
- conda_forge:    https://github.com/conda-forge/jinxed-feedstock
- pypi:           https://pypi.org/project/jinxed/2.1.0
- pypi inspector: https://inspector.pypi.io/project/jinxed/2.1.0

### Explanation of changes:

- new version number


[PKG-16695]: https://anaconda.atlassian.net/browse/PKG-16695?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ